### PR TITLE
Create an extension to provide syntax highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+grammars/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright © 2024 Jeffrey Guenther
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Shopify Liquid Extension for Zed
+
+This extension adds syntax highlighting for Liquid to Zed.
+
+More work is needed to bring this extension in line with vscode plugin, so
+contributions are welcome!

--- a/extension.toml
+++ b/extension.toml
@@ -5,3 +5,7 @@ schema_version = 1
 authors = ["Jeffrey Guenther <guenther.jeffrey@gmail.com>"]
 description = "Shopify Liquid support"
 repository = "https://github.com/TheBeyondGroup/zed-shopify-liquid"
+
+[grammars.liquid]
+repository = "https://github.com/hankthetank27/tree-sitter-liquid"
+commit = "293369818da219d97327908aab33707b04b63fd9"

--- a/languages/liquid/config.toml
+++ b/languages/liquid/config.toml
@@ -1,0 +1,5 @@
+name = "Liquid"
+grammar = "liquid"
+path_suffixes = ["liquid"]
+
+block_comment = ["{% comment %}", "{% endcomment %}"]

--- a/languages/liquid/highlights.scm
+++ b/languages/liquid/highlights.scm
@@ -1,0 +1,118 @@
+((comment) @comment @spell)
+
+(raw_statement
+  (raw_content) @spell)
+
+((identifier) @variable)
+
+((string) @string)
+
+((boolean) @boolean)
+
+((number) @number)
+
+(filter
+  name: (identifier) @function.special)
+
+([
+  "as"
+  "assign"
+  "capture"
+  "decrement"
+  "echo"
+  "endcapture"
+  "endform"
+  "endjavascript"
+  "endraw"
+  "endschema"
+  "endstyle"
+  "form"
+  "increment"
+  "javascript"
+  "layout"
+  "liquid"
+  "raw"
+  "schema"
+  "style"
+  "with"
+] @keyword)
+
+([
+  "case"
+  "else"
+  "elsif"
+  "endcase"
+  "endif"
+  "endunless"
+  "if"
+  "unless"
+  "when"
+] @keyword.conditional)
+
+([
+  "break"
+  "by"
+  "continue"
+  "cycle"
+  "endfor"
+  "endpaginate"
+  "endtablerow"
+  "for"
+  "paginate"
+  "tablerow"
+] @keyword.repeat)
+
+([
+  "and"
+  "contains"
+  "in"
+  "or"
+] @keyword.operator)
+
+([
+  "{{"
+  "}}"
+  "{{-"
+  "-}}"
+  "{%"
+  "%}"
+  "{%-"
+  "-%}"
+] @tag.delimiter)
+
+[
+  "include"
+  "render"
+  "section"
+  "sections"
+] @keyword.import
+
+[
+  "|"
+  ":"
+  "="
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "^"
+  "=="
+  "<"
+  "<="
+  "!="
+  ">="
+  ">"
+] @operator
+
+[
+  "]"
+  "["
+  ")"
+  "("
+] @punctuation.bracket
+
+[
+  ","
+  "."
+] @punctuation.delimiter

--- a/languages/liquid/injections.scm
+++ b/languages/liquid/injections.scm
@@ -1,0 +1,15 @@
+((template_content) @content
+  (#set! "language" "html")
+  (#set! "combined"))
+
+((json_content) @content
+  (#set! "language" "json")
+  (#set! "combined"))
+
+((style_content) @content
+  (#set! "language" "css")
+  (#set! "combined"))
+
+((js_content) @content
+  (#set! "language" "javascript")
+  (#set! "combined"))


### PR DESCRIPTION
In this PR, I add the work @mrnugget and I completed together. 

This extension provides syntax highlighting for Liquid. It is a start. More work is needed to integrate the language tools provided by Shopify.

This is a first step towards addressing https://github.com/zed-industries/extensions/issues/331