### PR TITLE
Remove “combined” from schema JSON injection

### DIFF
--- a/languages/liquid/injections.scm
+++ b/languages/liquid/injections.scm
@@ -9,8 +9,7 @@
 
 (schema_statement
   (json_content) @content
-  (#set! "language" "json")
-  (#set! "combined"))
+  (#set! "language" "json"))
 
 (style_statement
   (style_content) @content


### PR DESCRIPTION
Fixes #16 in my testing.

If I understand things correctly, I don’t think the JSON needs to be “combined” with Liquid anyway as, unlike CSS and JS injections, there is no Liquid syntax inside schema tags, just pure JSON.