### PR TITLE
Fix `injections.scm` syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "zed_liquid"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/languages/liquid/injections.scm
+++ b/languages/liquid/injections.scm
@@ -1,24 +1,20 @@
-((template_content) @content
-  (#set! "language" "html")
-  (#set! "combined"))
+((template_content) @injection.content
+  (#set! injection.language "html"))
 
 (javascript_statement
-  (js_content) @content
-  (#set! "language" "javascript")
-  (#set! "combined"))
+  (js_content) @injection.content
+  (#set! injection.language "javascript"))
 
 (schema_statement
-  (json_content) @content
-  (#set! "language" "json")
-  (#set! "combined"))
+  (json_content) @injection.content
+  (#set! injection.language "json"))
 
 (style_statement
-  (style_content) @content
-  (#set! "language" "css")
-  (#set! "combined"))
+  (style_content) @injection.content
+  (#set! injection.language "css"))
 
-((front_matter) @content
-  (#set! "language" "yaml"))
+((front_matter) @injection.content
+  (#set! injection.language "yaml"))
 
-((comment) @content
-  (#set! "language" "comment"))
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
Hello, we recently recieved an issue submitted in the Zed repo for JSON language injections in liquid files (https://github.com/zed-industries/zed/issues/30916) and when I checked out your `injections.scm`, I noticed it was using incorrect syntax for Zed.
I believe the method that was used is valid in NeoVim and may have been valid in Zed as well before my time at the company, but updating the syntax to the version that is definitely correct seems to have fixed the issue that was posted to Zed.

Cheers!
