### PR TITLE
Add brackets.scm for better vim navigation

### DIFF
--- a/languages/liquid/brackets.scm
+++ b/languages/liquid/brackets.scm
@@ -1,0 +1,6 @@
+("{{" @open "}}" @close)
+("{{-" @open "-}}" @close)
+("{%" @open "%}" @close)
+("{%-" @open "-%}" @close)
+("'" @open "'" @close)
+("\"" @open "\"" @close)

--- a/languages/liquid/config.toml
+++ b/languages/liquid/config.toml
@@ -1,5 +1,11 @@
 name = "Liquid"
 grammar = "liquid"
 path_suffixes = ["liquid"]
-
+brackets = [
+    { start = "{{", end = "}}", close = true, newline = false },
+    { start = "{{-", end = "-}}", close = true, newline = false },
+    { start = "{%", end = "%}", close = true, newline = false },
+    { start = "{%-", end = "-%}", close = true, newline = false },
+]
 block_comment = ["{% comment %}", "{% endcomment %}"]
+documentation = { start = "{% doc %}", end = "{% enddoc %}", prefix = " ", tab_size = 1 }


### PR DESCRIPTION
In this PR, I address #17. We want to be able toggle between the open and close of liquid interpolation.