### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_liquid"
-version = "0.5.0"
+version = "0.6.1"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "liquid"
 name = "Liquid"
-version = "0.5.0"
+version = "0.6.1"
 schema_version = 1
 authors = ["Jeffrey Guenther <guenther.jeffrey@gmail.com>"]
 description = "Shopify Liquid support"


### PR DESCRIPTION
## Summary
- Bump version from 0.5.0 to 0.6.1 in both `Cargo.toml` and `extension.toml`