### PR TITLE
chore: bump Cargo.lock version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "zed_liquid"
-version = "0.5.0"
+version = "0.6.1"
 dependencies = [
  "zed_extension_api",
 ]


### PR DESCRIPTION
## Summary
- Update `Cargo.lock` to reflect the 0.6.1 version bump (follows up on #31)