### PR TITLE
feat: align LiquidDoc param completions with Shopify VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Shopify Liquid Extension for Zed
 
 This extension adds syntax highlighting for Liquid to Zed.
+Language intelligence is powered by [`@shopify/theme-language-server-node`](https://github.com/Shopify/theme-tools).
 
 More work is needed to bring this extension in line with vscode plugin, so
 contributions are welcome!

--- a/lsp-proxy.js
+++ b/lsp-proxy.js
@@ -3,15 +3,19 @@
 
 const { spawn } = require("child_process");
 
-const shopifyRunJsPath = process.argv[2];
-if (!shopifyRunJsPath) {
-  process.stderr.write("Missing Shopify CLI run.js path.\n");
+const themeLanguageServerModulePath = process.argv[2];
+if (!themeLanguageServerModulePath) {
+  process.stderr.write("Missing Shopify theme language server module path.\n");
   process.exit(1);
 }
 
 const child = spawn(
   process.execPath,
-  [shopifyRunJsPath, "theme", "language-server"],
+  [
+    "-e",
+    "require(process.argv[1]).startServer()",
+    themeLanguageServerModulePath,
+  ],
   {
     stdio: ["pipe", "pipe", "inherit"],
     env: process.env,

--- a/src/liquid.rs
+++ b/src/liquid.rs
@@ -6,9 +6,9 @@ struct LiquidExtension {
     did_find_server: bool,
 }
 
-const SERVER_PATH: &str = "node_modules/@shopify/cli/bin/run.js";
+const SERVER_PATH: &str = "node_modules/@shopify/theme-language-server-node/dist/index.js";
 const PROXY_PATH: &str = "lsp-proxy.js";
-const PACKAGE_NAME: &str = "@shopify/cli";
+const PACKAGE_NAME: &str = "@shopify/theme-language-server-node";
 const PROXY_SCRIPT: &str = include_str!("../lsp-proxy.js");
 
 impl LiquidExtension {


### PR DESCRIPTION
## Summary
- switch the Zed extension backend package from `@shopify/cli` to `@shopify/theme-language-server-node`
- start the Shopify language server through the node package (`startServer()`) inside `lsp-proxy.js`
- keep existing proxy definition fallback logic intact
- document the language-intelligence backend in README

## Why
In snippets/blocks with `{% doc %}` and `@param {variant} variant`, typing `variant.` should suggest variant properties (same behavior as the Shopify VSCode extension).

## Validation
- `cargo check`
- `node --check lsp-proxy.js`
- manual LSP smoke test against `@shopify/theme-language-server-node` confirming completion items include `id` for `variant.`
