### PR TITLE
Fix: Allow for Liquid withing a schema-Block without breaking highlighting

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "liquid"
 name = "Liquid"
-version = "0.6.1"
+version = "0.5.1"
 schema_version = 1
 authors = ["Jeffrey Guenther <guenther.jeffrey@gmail.com>"]
 description = "Shopify Liquid support"
@@ -8,7 +8,7 @@ repository = "https://github.com/TheBeyondGroup/zed-shopify-liquid"
 
 [grammars.liquid]
 repository = "https://github.com/hankthetank27/tree-sitter-liquid"
-commit = "fa11c7ba45038b61e03a8a00ad667fb5f3d72088"
+commit = "9566ca79911052919fce09d26f1f655b5e093857"
 
 [language_servers.liquid]
 name = "Liquid LSP"


### PR DESCRIPTION
The fix itself is in the tree-sitter-liquid repository and only contains changes to the grammar.js.