### PR TITLE
chore: use latest liquid grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "zed_liquid"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_liquid"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "liquid"
 name = "Liquid"
-version = "0.6.1"
+version = "0.6.2"
 schema_version = 1
 authors = ["Jeffrey Guenther <guenther.jeffrey@gmail.com>"]
 description = "Shopify Liquid support"
@@ -8,7 +8,7 @@ repository = "https://github.com/TheBeyondGroup/zed-shopify-liquid"
 
 [grammars.liquid]
 repository = "https://github.com/hankthetank27/tree-sitter-liquid"
-commit = "fa11c7ba45038b61e03a8a00ad667fb5f3d72088"
+commit = "9566ca79911052919fce09d26f1f655b5e093857"
 
 [language_servers.liquid]
 name = "Liquid LSP"


### PR DESCRIPTION
Updates to the latest liquid grammar. Duplicates #35 with a different version number and cleaner commit.