### PR TITLE
Fix syntax scopes for delimiters and argument keys

### DIFF
--- a/languages/liquid/highlights.scm
+++ b/languages/liquid/highlights.scm
@@ -5,6 +5,10 @@
   (raw_content) @spell
   (#set! priority 110))
 
+(argument
+  key: (identifier) @variable.parameter
+  (#set! priority 111))
+
 ((identifier) @variable
   (#set! priority 110))
 
@@ -92,7 +96,7 @@
   "%}"
   "{%-"
   "-%}"
-] @tag.delimiter
+] @punctuation.special
   (#set! priority 110))
 
 [


### PR DESCRIPTION
Fixes #29

## Changes

- **Delimiters** (`{{`, `}}`, `{%`, `%}`, etc.): Changed from `@tag.delimiter` to `@punctuation.special`. These are template delimiters, not HTML tags.

- **Keyword argument keys** (e.g. `page:` in `{% render 'card', page: page %}`): Added `@variable.parameter` scope at a higher priority so argument keys are distinguished from regular `@variable` identifiers.

## Test

```liquid
{% render 'card', product: product, show_badge: true %}
{% include 'header', title: page_title %}
{{ product.price | default: 0, allow_false: true }}
{% for item in collection %}
  {{ item.name }}
{% endfor %}
{%- assign greeting = "hello" -%}
{{- greeting -}}
```