### PR TITLE
Update huacnlee/zed-extension-action from v1 to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Release Zed Extension
     runs-on: ubuntu-latest
     steps:
-      - uses: huacnlee/zed-extension-action@v1
+      - uses: huacnlee/zed-extension-action@v2
         with:
           extension-name: liquid
           # extension-path: extensions/${{ extension-name }}


### PR DESCRIPTION
Updates the release workflow to use huacnlee/zed-extension-action v2.

**What changed in v2:**
- Adds support for a `git-reference` parameter to specify any tag, branch, or commit ([release notes](https://github.com/huacnlee/zed-extension-action/releases/tag/v2.0.0))