### PR TITLE
Improve bracket pairs config for auto-close

### DIFF
--- a/languages/liquid/config.toml
+++ b/languages/liquid/config.toml
@@ -1,11 +1,31 @@
 name = "Liquid"
 grammar = "liquid"
 path_suffixes = ["liquid"]
-brackets = [
-    { start = "{{", end = "}}", close = true, newline = false },
-    { start = "{{-", end = "-}}", close = true, newline = false },
-    { start = "{%", end = "%}", close = true, newline = false },
-    { start = "{%-", end = "-%}", close = true, newline = false },
-]
 block_comment = ["{% comment %}", "{% endcomment %}"]
 documentation = { start = "{% doc %}", end = "{% enddoc %}", prefix = " ", tab_size = 1 }
+tab_size = 2
+hard_tabs = false
+autoclose_before = "%-:.,=}])<>'\"` \n\t"
+word_characters = ["-", "_"]
+
+brackets = [
+    # Space-padded variants: typing space after a delimiter auto-closes
+    # with inner padding, e.g. `{{|}}` + space produces `{{ | }}`.
+    { start = "{{ ", end = " }}", close = true, newline = false },
+    { start = "{% ", end = " %}", close = true, newline = false },
+    { start = "{{- ", end = " -}}", close = true, newline = false },
+    { start = "{%- ", end = " -%}", close = true, newline = false },
+    # Whitespace-trimming variants
+    { start = "{{-", end = "-}}", close = true, newline = false },
+    { start = "{%-", end = "-%}", close = true, newline = false },
+    # Base Liquid delimiters
+    { start = "{{", end = "}}", close = true, newline = false },
+    { start = "{%", end = "%}", close = true, newline = false },
+    # Standard brackets
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "<", end = ">", close = true, newline = false },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string", "comment"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
+]


### PR DESCRIPTION
## Summary

Improves the `config.toml` bracket pairs configuration to fix auto-close behavior and add inner padding for Liquid delimiters.

### Changes

- **`autoclose_before`**: Added so auto-close triggers correctly before Liquid-specific characters (`%`, `-`, whitespace, etc.). Without this, auto-close was blocked in many contexts because the injected HTML language's restrictive `autoclose_before` (`>})`) was used instead.
- **Space-padded bracket pairs**: `{{ `/` }}`, `{% `/` %}`, `{{- `/` -}}`, `{%- `/` -%}` — typing space after a delimiter produces the conventional padded form (e.g., `{{ | }}`).
- **Standard brackets**: Added missing pairs for `{}`, `[]`, `()`, `<>`, quotes — these were absent from the config.
- **`word_characters`** and **`tab_size`** settings.

### Behavior

| Input | Before | After |
|-------|--------|-------|
| `{{` + space | `{{ \|}}` | `{{ \| }}` |
| `{%` + space | `{% \|%}` | `{% \| %}` |
| `{{-` + space | `{{- \|-}}` | `{{- \| -}}` |

> **Note**: The space-padded pairs rely on the multi-character bracket supersession feature proposed in [zed-industries/zed#54049](https://github.com/zed-industries/zed/pull/54049). Without that Zed change, only the base delimiter auto-close (`{{`→`{{|}}`, `{%`→`{%|%}`) works.

Related: #42